### PR TITLE
Fix leading zeros serialization in DecimalItem

### DIFF
--- a/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
+++ b/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
@@ -29,7 +29,9 @@ public class DecimalItem implements NumberItem<BigDecimal> {
     private static final long MIN = -999999999999999L;
     private static final long MAX = 999999999999999L;
     private static final BigDecimal THOUSAND = new BigDecimal(1000);
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US));
+    private static final ThreadLocal<DecimalFormat> DECIMAL_FORMAT_TL = ThreadLocal.withInitial(() ->
+        new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US))
+    );
 
     private DecimalItem(long value, Parameters params) {
         if (value < MIN || value > MAX) {
@@ -80,7 +82,7 @@ public class DecimalItem implements NumberItem<BigDecimal> {
 
     @Override
     public StringBuilder serializeTo(StringBuilder sb) {
-        sb.append(DECIMAL_FORMAT.format(get()));
+        sb.append(DECIMAL_FORMAT_TL.get().format(get()));
         params.serializeTo(sb);
         return sb;
     }

--- a/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
+++ b/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
@@ -29,9 +29,7 @@ public class DecimalItem implements NumberItem<BigDecimal> {
     private static final long MIN = -999999999999999L;
     private static final long MAX = 999999999999999L;
     private static final BigDecimal THOUSAND = new BigDecimal(1000);
-    private static final ThreadLocal<DecimalFormat> DECIMAL_FORMAT_TL = ThreadLocal.withInitial(() ->
-        new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US))
-    );
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US));
 
     private DecimalItem(long value, Parameters params) {
         if (value < MIN || value > MAX) {
@@ -82,7 +80,7 @@ public class DecimalItem implements NumberItem<BigDecimal> {
 
     @Override
     public StringBuilder serializeTo(StringBuilder sb) {
-        sb.append(DECIMAL_FORMAT_TL.get().format(get()));
+        sb.append(DECIMAL_FORMAT.format(get()));
         params.serializeTo(sb);
         return sb;
     }

--- a/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
+++ b/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
@@ -83,13 +83,13 @@ public class DecimalItem implements NumberItem<BigDecimal> {
         long left = abs / 1000;
         long right = abs % 1000;
 
-        if (right % 10 == 0) {
-            right /= 10;
+        sb.append(sign).append(left).append('.').append(right / 100);
+        if (right % 100 != 0) {
+            sb.append((right / 10) % 10);
+            if (right % 10 != 0) {
+                sb.append(right % 10);
+            }
         }
-        if (right % 10 == 0) {
-            right /= 10;
-        }
-        sb.append(sign).append(left).append('.').append(right);
 
         params.serializeTo(sb);
 

--- a/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
+++ b/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
@@ -1,9 +1,6 @@
 package org.greenbytes.http.sfv;
 
 import java.math.BigDecimal;
-import java.text.DecimalFormat;
-import java.text.DecimalFormatSymbols;
-import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -29,7 +26,6 @@ public class DecimalItem implements NumberItem<BigDecimal> {
     private static final long MIN = -999999999999999L;
     private static final long MAX = 999999999999999L;
     private static final BigDecimal THOUSAND = new BigDecimal(1000);
-    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US));
 
     private DecimalItem(long value, Parameters params) {
         if (value < MIN || value > MAX) {
@@ -80,8 +76,23 @@ public class DecimalItem implements NumberItem<BigDecimal> {
 
     @Override
     public StringBuilder serializeTo(StringBuilder sb) {
-        sb.append(DECIMAL_FORMAT.format(get()));
+
+        String sign = value < 0 ? "-" : "";
+
+        long abs = Math.abs(value);
+        long left = abs / 1000;
+        long right = abs % 1000;
+
+        if (right % 10 == 0) {
+            right /= 10;
+        }
+        if (right % 10 == 0) {
+            right /= 10;
+        }
+        sb.append(sign).append(left).append('.').append(right);
+
         params.serializeTo(sb);
+
         return sb;
     }
 

--- a/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
+++ b/src/main/java/org/greenbytes/http/sfv/DecimalItem.java
@@ -1,6 +1,9 @@
 package org.greenbytes.http.sfv;
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.Locale;
 import java.util.Objects;
 
 /**
@@ -26,6 +29,7 @@ public class DecimalItem implements NumberItem<BigDecimal> {
     private static final long MIN = -999999999999999L;
     private static final long MAX = 999999999999999L;
     private static final BigDecimal THOUSAND = new BigDecimal(1000);
+    private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.0##", new DecimalFormatSymbols(Locale.US));
 
     private DecimalItem(long value, Parameters params) {
         if (value < MIN || value > MAX) {
@@ -76,23 +80,8 @@ public class DecimalItem implements NumberItem<BigDecimal> {
 
     @Override
     public StringBuilder serializeTo(StringBuilder sb) {
-
-        String sign = value < 0 ? "-" : "";
-
-        long abs = Math.abs(value);
-        long left = abs / 1000;
-        long right = abs % 1000;
-
-        if (right % 10 == 0) {
-            right /= 10;
-        }
-        if (right % 10 == 0) {
-            right /= 10;
-        }
-        sb.append(sign).append(left).append('.').append(right);
-
+        sb.append(DECIMAL_FORMAT.format(get()));
         params.serializeTo(sb);
-
         return sb;
     }
 

--- a/src/test/java/org/greenbytes/http/sfv/ItemAPITests.java
+++ b/src/test/java/org/greenbytes/http/sfv/ItemAPITests.java
@@ -92,6 +92,17 @@ public class ItemAPITests {
     }
 
     @Test
+    public void testDecimalSerializationIntegerValues() {
+
+        String[] tests = new String[] { "0.0", "1000.0", "-1000.0", "5000.0", "123000.0" };
+
+        for (String s : tests) {
+            DecimalItem item = DecimalItem.valueOf(new BigDecimal(s));
+            assertEquals(s, item.serialize());
+        } 
+    }
+
+    @Test
     public void testString() {
 
         String[] tests = new String[] { "", "'", "\"", "\\" };

--- a/src/test/java/org/greenbytes/http/sfv/ItemAPITests.java
+++ b/src/test/java/org/greenbytes/http/sfv/ItemAPITests.java
@@ -81,6 +81,17 @@ public class ItemAPITests {
     }
 
     @Test
+    public void testDecimalSerializationLeadingZeros() {
+
+        String[] tests = new String[] { "100.012", "1.001", "0.01", "0.001", "-100.012" };
+
+        for (String s : tests) {
+            DecimalItem item = DecimalItem.valueOf(new BigDecimal(s));
+            assertEquals(s, item.serialize());
+        }
+    }
+
+    @Test
     public void testString() {
 
         String[] tests = new String[] { "", "'", "\"", "\\" };


### PR DESCRIPTION
Fixes a serialization issue in `DecimalItems` with leading zeros. It also adds two unit tests to verify serialization: the first tests the leading zeros issue, and the second tests that integer values are serialized correctly (with a trailing `.0`).

| String value | Serialized value before fix | After fix |
|--------------|-----------------------------|-----------|
| "0.01"       | 0.1                         | 0.01      |
| "0.021"      | 0.21                        | 0.021     |
| "1.0"        | 1.0                         | 1.0       |